### PR TITLE
only use first two coordinates when calculating length

### DIFF
--- a/geojson_length/geojson_length.py
+++ b/geojson_length/geojson_length.py
@@ -24,8 +24,8 @@ def distance_between_two_points(
     """
 
     # GeoPy needs lat, lon
-    point1 = tuple(reversed(point1[0:2]))
-    point2 = tuple(reversed(point2[0:2]))
+    point1 = tuple(reversed(point1[:2]))
+    point2 = tuple(reversed(point2[:2]))
 
     if unit == Unit.meters:
         return geopy.distance.distance(point1, point2).meters

--- a/geojson_length/geojson_length.py
+++ b/geojson_length/geojson_length.py
@@ -24,8 +24,8 @@ def distance_between_two_points(
     """
 
     # GeoPy needs lat, lon
-    point1 = tuple(reversed(point1))
-    point2 = tuple(reversed(point2))
+    point1 = tuple(reversed(point1[0:2]))
+    point2 = tuple(reversed(point2[0:2]))
 
     if unit == Unit.meters:
         return geopy.distance.distance(point1, point2).meters

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,6 @@ twine==1.14.0
 
 pytest==4.6.5
 pytest-runner==5.1
+
+geopy==2.0.0
+

--- a/tests/test_geojson_length.py
+++ b/tests/test_geojson_length.py
@@ -28,6 +28,24 @@ def geojson_santiago_bernabeu():
         },
     }
 
+@pytest.fixture
+def geojson_santiago_bernabeu_w_alt():
+    """
+    Santiago Bernabéu Stadium has 105m
+    """
+    #
+    return {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [
+                [-3.688431680202484, 40.453537706073185, 698.0],
+                [-3.6885067820549016, 40.45259884887462, 698.0],
+            ],
+        },
+    }
+
 
 @pytest.fixture
 def geojson_wenceslas_square():
@@ -63,6 +81,12 @@ def test_length_sb(geojson_santiago_bernabeu):
     assert calculate_distance(
         geojson_santiago_bernabeu, unit=Unit.yards
     ) == pytest.approx(114.51, rel=1e-1)
+
+
+def test_length_sb(geojson_santiago_bernabeu_w_alt):
+    assert calculate_distance(
+        geojson_santiago_bernabeu_w_alt, unit=Unit.meters
+    ) == pytest.approx(104.71, rel=1e-1)
 
 
 def test_length_ws(geojson_wenceslas_square):


### PR DESCRIPTION
I encountered errors when I used geojson which included altitude.

Proposed patch simply ignored the third value in the array, if present.